### PR TITLE
chore: reduce dependabot PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,50 +3,49 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
       day: monday
       time: "09:00"
       timezone: "America/Sao_Paulo"
     commit-message:
       prefix: chore
       include: scope
-    open-pull-requests-limit: 8
+    open-pull-requests-limit: 4
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
-      eslint:
-        patterns:
-          - "eslint*"
-          - "@typescript-eslint/*"
-      testing:
-        patterns:
-          - "jest*"
-          - "@jest/*"
-          - "@testing-library/*"
-          - "cypress*"
-          - "@cypress/*"
-      typescript:
-        patterns:
-          - "typescript"
-          - "ts-*"
-          - "@types/*"
-      mui:
-        patterns:
-          - "@mui/*"
-      webpack:
-        patterns:
-          - "webpack*"
-          - "*loader"
-      i18n:
-        patterns:
-          - "i18next*"
-          - "react-i18next"
+      production-minor-patch:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+      development-minor-patch:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      major-updates:
+        update-types:
+          - major
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
       day: monday
       time: "09:00"
       timezone: "America/Sao_Paulo"
     commit-message:
       prefix: chore
       include: scope
+    open-pull-requests-limit: 2
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary
- reduce npm Dependabot update frequency from weekly to monthly
- batch npm updates into production, development, and major groups
- add cooldowns and tighter open PR limits for npm and GitHub Actions
- group GitHub Actions updates into a single PR

## Testing
- npm run verify