### PR TITLE
feat: add Strava social link

### DIFF
--- a/src/components/social/SocialBar.tsx
+++ b/src/components/social/SocialBar.tsx
@@ -6,10 +6,12 @@ import { SxProps, Theme } from "@mui/system";
 import { useTranslation } from "react-i18next";
 import { tLiteral } from "../../i18n/literal";
 import { SocialButton } from "../button";
+import { StravaIcon } from "./StravaIcon";
 
 export interface SocialUrls {
   github: string;
   linkedin: string;
+  strava: string;
   x: string;
 }
 
@@ -22,18 +24,21 @@ const SOCIAL_ICON_MAP = {
   github: <GitHubIcon />,
   x: <XIcon />,
   linkedin: <LinkedInIcon />,
+  strava: <StravaIcon />,
 };
 
 const SOCIAL_URL_KEY_MAP = {
   github: "github",
   x: "x",
   linkedin: "linkedin",
+  strava: "strava",
 } as const;
 
 const SOCIAL_ITEMS = [
   { key: "github", labelKey: "github" },
   { key: "x", labelKey: "x" },
   { key: "linkedin", labelKey: "linkedin" },
+  { key: "strava", labelKey: "strava" },
 ] as const;
 
 export function SocialBar(props: SocialBarProps) {

--- a/src/components/social/StravaIcon.tsx
+++ b/src/components/social/StravaIcon.tsx
@@ -1,0 +1,9 @@
+import SvgIcon from "@mui/material/SvgIcon";
+
+export function StravaIcon() {
+  return (
+    <SvgIcon viewBox="0 0 24 24">
+      <path d="M15.387 17.944l-2.089-4.116h-3.065L15.387 24l5.15-10.172h-3.066M10.463 8.229l2.836 5.599h4.172L10.463 0l-7 13.828h4.169" />
+    </SvgIcon>
+  );
+}

--- a/src/components/social/__tests__/SocialBar.test.tsx
+++ b/src/components/social/__tests__/SocialBar.test.tsx
@@ -6,8 +6,9 @@ import { SocialBar, SocialUrls } from "../SocialBar";
 describe("SocialBar", () => {
   const urls: SocialUrls = {
     github: "https://github.com/example",
-    x: "https://x.com/example",
     linkedin: "https://linkedin.com/in/example",
+    strava: "https://www.strava.com/athletes/example",
+    x: "https://x.com/example",
   };
 
   it("should render all social links", () => {
@@ -16,12 +17,14 @@ describe("SocialBar", () => {
     const githubLink = getByRole("link", { name: "Open github" });
     const xLink = getByRole("link", { name: "Open x" });
     const linkedinLink = getByRole("link", { name: "Open linkedin" });
+    const stravaLink = getByRole("link", { name: "Open strava" });
 
     expect(githubLink).toHaveAttribute("href", urls.github);
     expect(xLink).toHaveAttribute("href", urls.x);
     expect(linkedinLink).toHaveAttribute("href", urls.linkedin);
+    expect(stravaLink).toHaveAttribute("href", urls.strava);
 
-    [githubLink, xLink, linkedinLink].forEach((link) => {
+    [githubLink, xLink, linkedinLink, stravaLink].forEach((link) => {
       expect(link).toHaveAttribute("target", "_blank");
       expect(link).toHaveAttribute("rel", "noopener noreferrer");
     });

--- a/src/components/social/index.ts
+++ b/src/components/social/index.ts
@@ -1,1 +1,2 @@
 export { SocialBar } from "./SocialBar";
+export { StravaIcon } from "./StravaIcon";

--- a/src/context/__tests__/AppContext.test.tsx
+++ b/src/context/__tests__/AppContext.test.tsx
@@ -22,6 +22,7 @@ const APP_SCHEMA: AppSchema = {
     urls: {
       github: "https://github.com/johndoe",
       linkedin: "https://linkedin.com/in/johndoe",
+      strava: "https://www.strava.com/athletes/johndoe",
       x: "https://x.com/johndoe",
     },
   },

--- a/src/hooks/__tests__/useSchema.test.tsx
+++ b/src/hooks/__tests__/useSchema.test.tsx
@@ -26,6 +26,7 @@ describe("useSchema :: integration", () => {
     expect(schema.personal.urls).toEqual({
       github: "https://github.com/caponetto",
       linkedin: "https://www.linkedin.com/in/ghcaponetto",
+      strava: "https://www.strava.com/athletes/34965373",
       x: "https://x.com/caponetto",
     });
     expect(schema.personal.email).toBe("hey@caponetto.dev");

--- a/src/pages/About/__tests__/__snapshots__/AboutPage.test.tsx.snap
+++ b/src/pages/About/__tests__/__snapshots__/AboutPage.test.tsx.snap
@@ -226,6 +226,34 @@ exports[`AboutPage should match the snapshot 1`] = `
                     </a>
                   </div>
                 </div>
+                <div
+                  class="MuiGrid-root MuiGrid-direction-xs-row MuiGrid-grid-xs-grow css-1ynczkt-MuiGrid-root"
+                >
+                  <div
+                    class="MuiBox-root css-1l4w6pd"
+                  >
+                    <a
+                      aria-label="Open strava"
+                      class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeMedium css-1uwfzqa-MuiButtonBase-root-MuiIconButton-root"
+                      data-mui-internal-clone-element="true"
+                      href="https://www.strava.com/athletes/34965373"
+                      rel="noopener noreferrer"
+                      tabindex="0"
+                      target="_blank"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium css-1umw9bq-MuiSvgIcon-root"
+                        focusable="false"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          d="M15.387 17.944l-2.089-4.116h-3.065L15.387 24l5.15-10.172h-3.066M10.463 8.229l2.836 5.599h4.172L10.463 0l-7 13.828h4.169"
+                        />
+                      </svg>
+                    </a>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/src/schema/appSchemas.ts
+++ b/src/schema/appSchemas.ts
@@ -43,6 +43,7 @@ export const personalSchema = z.object({
   urls: z.object({
     github: z.url(),
     linkedin: z.url(),
+    strava: z.url(),
     x: z.url(),
   }),
 });

--- a/src/schema/mappers/__tests__/profile.test.ts
+++ b/src/schema/mappers/__tests__/profile.test.ts
@@ -12,6 +12,7 @@ describe("profile mappers", () => {
     expect(personal.email).toBe("hey@caponetto.dev");
     expect(personal.country.name).toBe("literal:brazil");
     expect(personal.urls.github).toBe("https://github.com/caponetto");
+    expect(personal.urls.strava).toBe("https://www.strava.com/athletes/34965373");
   });
 
   it("builds about paragraphs from array and filters non-strings", () => {

--- a/src/schema/mappers/profile.ts
+++ b/src/schema/mappers/profile.ts
@@ -15,6 +15,7 @@ export function buildPersonal(t: TFunction): Personal {
     urls: {
       github: "https://github.com/caponetto",
       linkedin: "https://www.linkedin.com/in/ghcaponetto",
+      strava: "https://www.strava.com/athletes/34965373",
       x: "https://x.com/caponetto",
     },
   };

--- a/static/locales/en/literal.json
+++ b/static/locales/en/literal.json
@@ -120,6 +120,7 @@
   "speechEnhancement": "Speech Enhancement",
   "springFramework": "Spring Framework",
   "sql": "SQL",
+  "strava": "Strava",
   "syncRepositories": "Sync Repositories",
   "systemDesign": "System Design",
   "talk": "Talks",

--- a/static/locales/es/literal.json
+++ b/static/locales/es/literal.json
@@ -120,6 +120,7 @@
   "speechEnhancement": "Mejora de la Voz",
   "springFramework": "Spring Framework",
   "sql": "SQL",
+  "strava": "Strava",
   "syncRepositories": "Sincronización de Repositorios",
   "systemDesign": "Diseño de sistemas",
   "talk": "Charlas",

--- a/static/locales/pt/literal.json
+++ b/static/locales/pt/literal.json
@@ -120,6 +120,7 @@
   "speechEnhancement": "Melhoria de Voz",
   "springFramework": "Spring Framework",
   "sql": "SQL",
+  "strava": "Strava",
   "syncRepositories": "Sincronização de Repositórios",
   "systemDesign": "System Design",
   "talk": "Palestras",


### PR DESCRIPTION
## Summary

Adds a Strava button to the social bar.

## Changes

- Added a reusable `StravaIcon` component with a monochrome MUI `SvgIcon`
- Wired Strava into the social bar, profile mapper, schema, and localized literal labels
- Updated unit expectations and the About page snapshot

## Verification

- `npm run check:types`
- `npm run test:unit -- SocialBar.test.tsx profile.test.ts useSchema.test.tsx`
- `npm run check:locales`
- `npm run lint`
- `npm run test:unit -- AboutPage.test.tsx -u`